### PR TITLE
Potential fix for code scanning alert no. 51: Uncontrolled command line

### DIFF
--- a/hardwaremon_app/backend_fastapi/telemetry/network.py
+++ b/hardwaremon_app/backend_fastapi/telemetry/network.py
@@ -220,14 +220,20 @@ def ping_target(request: PingRequest) -> dict[str, Any]:
             "error": str(error),
         }
 
-    command = _ping_command(resolved_host, request.count, request.timeout)
+    safe_count = max(1, min(10, int(request.count)))
+    safe_timeout = float(request.timeout)
+    if not math.isfinite(safe_timeout):
+        safe_timeout = 1.0
+    safe_timeout = max(0.2, min(5.0, safe_timeout))
+
+    command = _ping_command(resolved_host, safe_count, safe_timeout)
     try:
         completed = subprocess.run(
             command,
             capture_output=True,
             text=True,
             errors="replace",
-            timeout=min(60.0, (request.count * request.timeout) + 3.0),
+            timeout=min(60.0, (safe_count * safe_timeout) + 3.0),
             check=False,
             shell=False,
             **hidden_process_kwargs(),


### PR DESCRIPTION
Potential fix for [https://github.com/louisboii747/HardwareMon/security/code-scanning/51](https://github.com/louisboii747/HardwareMon/security/code-scanning/51)

General fix: ensure any user-controlled values used in process arguments are validated and clamped to a strict safe range before constructing the command. Keep command executable and flags hard-coded; only permit sanitized numeric parameters and validated/resolved target values.

Best fix here (without changing functionality): in `ping_target` (around lines 223–230), introduce local sanitized variables for `count` and `timeout`, enforce finite numeric values and bounded ranges, then pass only these sanitized values to `_ping_command` and to the subprocess timeout calculation. This preserves behavior while breaking direct taint flow from request fields to the sink and prevents extreme values.

Edits needed in `hardwaremon_app/backend_fastapi/telemetry/network.py`:
- In `ping_target`, before building `command`, add:
  - `safe_count = max(1, min(10, int(request.count)))`
  - `safe_timeout = float(request.timeout)` with finite check and clamping, e.g. `0.2..5.0`
- Replace `_ping_command(resolved_host, request.count, request.timeout)` with `_ping_command(resolved_host, safe_count, safe_timeout)`
- Replace subprocess timeout expression to use sanitized values.

No new imports are needed (`math` is already imported).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
